### PR TITLE
Prevent Cmake from checking for a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ CMAKE_FORCE_C_COMPILER(${SH_ELF_GCC} GNU)
 CMAKE_FORCE_CXX_COMPILER(${SH_ELF_GPP} GNU)
 SET(CMAKE_FIND_ROOT_PATH /usr/local/share/sh-elf/bin)
 
-PROJECT(iapetus)
+PROJECT(iapetus C)
 
 #CONFIGURE_FILE(config.h.cmake config.h)
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(iapetus-doc)
+project(iapetus-doc C)
 
 find_package(Doxygen)
 if(DOXYGEN_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(iapetus)
+project(iapetus C)
 
 enable_language(ASM)
 set(iapetus_SOURCES

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(exhello)
+project(exhello C)
 set(exhello_SOURCES exhello.c)
 set(CMAKE_C_FLAGS "-O2 -Wall -m2 -DREENTRANT_SYSCALLS_PROVIDED")
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
@@ -9,7 +9,7 @@ install(TARGETS ${PROJECT_NAME} DESTINATION "examples")
 install(DIRECTORY "" DESTINATION "examples" FILES_MATCHING PATTERN "*.c")
 
 
-project(exgui)
+project(exgui C)
 set(exgui_SOURCES exgui.c)
 set(CMAKE_C_FLAGS "-O2 -Wall -m2 -DREENTRANT_SYSCALLS_PROVIDED")
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
By default Cmake will error if a C++ compiler isn't present. These changes allow Iapetus to be compiled even without a C++ compiler installed.